### PR TITLE
feat(frontend): add toast UX and barcode scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Node / frontend
+frontend/node_modules/
+frontend/dist/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.vscode/
+.idea/
+.DS_Store

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,91 @@
+# POS Frontend (React + Vite)
+
+Single screen Point of Sale UI built with React 18, TypeScript, Tailwind CSS, Zustand and TanStack Query. The app talks to the existing Django backend via the provided REST endpoints and keeps the current localStorage contract (`pos.front.state`).
+
+## Requisitos
+
+- Node.js 20+
+- pnpm 8+ (recomendado). También se puede usar npm, pero los comandos de ejemplo usan pnpm.
+
+## Comandos
+
+```bash
+pnpm install      # instala dependencias
+pnpm dev          # arranca Vite en modo desarrollo (http://localhost:5173)
+pnpm build        # genera build listo para producción en dist/
+pnpm preview      # sirve el build para verificación
+pnpm test         # ejecuta las pruebas unitarias (Vitest)
+```
+
+Durante el desarrollo Vite proxea automáticamente `/api`, `/producto` y `/auth_app` hacia `http://localhost:8000` para evitar problemas de CORS.
+
+## Integración con Django
+
+1. Ejecuta `pnpm build` para generar la carpeta `dist/`.
+2. Copia el contenido de `dist/` a la carpeta estática de Django, por ejemplo `core/static/pos/`.
+3. Ajusta la plantilla de Django para incluir el bundle principal (`assets/index-*.js`) y la hoja de estilos (`assets/index-*.css`). Si usas `django.contrib.staticfiles`, basta con referenciar `static('pos/index.html')` o servir el build como plantilla principal.
+4. Recuerda ejecutar `python manage.py collectstatic` en despliegues productivos.
+5. El bundle se comporta como una SPA. Django debe seguir sirviendo los endpoints API y la cookie CSRF.
+
+### Incluir en una plantilla existente
+
+```django
+{% load static %}
+<div id="root"></div>
+<script defer src="{% static 'pos/assets/index-XYZ.js' %}"></script>
+<link rel="stylesheet" href="{% static 'pos/assets/index-XYZ.css' %}" />
+```
+
+## Hotkeys por defecto
+
+| Acción | Atajo |
+| --- | --- |
+| Foco buscador | `Ctrl + K` |
+| Abrir/cerrar carrito | `F2` |
+| Descuento de línea (selecciona primera línea) | `F7` |
+| Logística | `F8` |
+| Clientes | `F9` |
+| Guardar carrito remoto | `F10` |
+| Simulador de pagos | `F6` |
+| Multipago (placeholder) | `Shift + F6` |
+| Ayuda / ver listado de atajos | `F1` |
+
+## Notas funcionales
+
+- Escaneo de códigos de barras:
+  - El input admite lectores USB (modo teclado).
+  - Si el navegador soporta `BarcodeDetector`, se habilita un botón para escanear usando la cámara.
+- Persistencia: el estado del carrito se guarda en localStorage (`pos.front.state`) y se sincroniza automáticamente (debounce ~400ms) con `/api/save_user_cart` cuando hay sesión y conexión.
+- El modal de simulador de pagos usa `window.SIMULATOR_V5_URL`. Asegúrate de definirlo antes de montar la app si se necesita.
+- El botón **Imprimir presupuesto** abre una ventana imprimible lista para `Ctrl + P`.
+- Panel auxiliar para Pedidos y Presupuestos permite buscar por número (placeholder; mostrará toasts hasta que la integración esté disponible).
+- Los toasts se muestran en la esquina inferior para errores, advertencias o confirmaciones.
+
+## Estilos y accesibilidad
+
+- Tailwind CSS con tema oscuro/claro controlado desde la barra superior.
+- Focus visible y navegación por teclado para los componentes interactivos.
+- Componentes de modal con `aria-modal` y cierre vía `Escape`.
+
+## Configuración adicional
+
+- Puedes personalizar los atajos desde `useUiStore` si en el futuro se expone un editor de atajos.
+- El almacén preferido se actualiza vía `/api/update_last_store` al seleccionar una sucursal.
+
+## Estructura relevante
+
+```
+src/
+  api/           # wrappers fetch + normalizadores de respuestas
+  components/    # UI (TopBar, CartPanel, modales, etc.)
+  hooks/         # hooks reutilizables (hotkeys, barcode, sync remoto)
+  stores/        # Zustand stores (cart, filtros, UI, sesión, toasts)
+  utils/         # helpers (totales, normalizadores, impresión)
+  pages/POS.tsx  # vista única del POS
+```
+
+## Troubleshooting
+
+- Si la cámara no aparece al escanear, verifica que el sitio esté servido sobre HTTPS o localhost y concede permisos manualmente.
+- En modo offline, los cambios se siguen guardando localmente; se mostrará un toast cuando falle la sincronización con el backend.
+- Para limpiar completamente el estado local usa la consola del navegador: `localStorage.removeItem('pos.front.state')`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@types/react": "^19.1.14",
@@ -16,7 +17,8 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.15",
     "typescript": "~5.8.3",
-    "vite": "^7.1.7"
+    "vite": "^7.1.7",
+    "vitest": "^2.1.4"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 ﻿import { useEffect } from 'react';
 import { POSPage } from './pages/POS';
+import { ToastContainer } from './components/ToastContainer';
 import { useUiStore } from './stores/useUiStore';
 
 const App = () => {
@@ -12,7 +13,12 @@ const App = () => {
     root.classList.toggle('dark', theme === 'dark');
   }, [theme]);
 
-  return <POSPage />;
+  return (
+    <>
+      <POSPage />
+      <ToastContainer />
+    </>
+  );
 };
 
 export default App;

--- a/frontend/src/components/AuxiliarySearchPanels.tsx
+++ b/frontend/src/components/AuxiliarySearchPanels.tsx
@@ -1,0 +1,80 @@
+import { useMemo, useState } from 'react';
+import { clsx } from 'clsx';
+
+interface Props {
+  onSearchOrder: (orderNumber: string) => void;
+  onSearchQuote: (quoteNumber: string) => void;
+}
+
+type TabKey = 'orders' | 'quotes';
+
+const tabs: { key: TabKey; label: string; helper: string; placeholder: string }[] = [
+  { key: 'orders', label: 'Pedidos', helper: 'Busca pedidos confirmados para retomarlos rápidamente.', placeholder: 'Número de pedido' },
+  { key: 'quotes', label: 'Presupuestos', helper: 'Accede a presupuestos guardados para imprimir o continuar.', placeholder: 'Número de presupuesto' },
+];
+
+export const AuxiliarySearchPanels = ({ onSearchOrder, onSearchQuote }: Props) => {
+  const [active, setActive] = useState<TabKey>('orders');
+  const [value, setValue] = useState('');
+
+  const currentTab = useMemo(() => tabs.find((tab) => tab.key === active) ?? tabs[0], [active]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const normalized = value.trim();
+    if (!normalized) return;
+    if (active === 'orders') {
+      onSearchOrder(normalized);
+    } else {
+      onSearchQuote(normalized);
+    }
+    setValue('');
+  };
+
+  return (
+    <section className="rounded-2xl border border-slate-800/80 bg-slate-950/70 p-4 shadow-lg">
+      <header className="flex flex-wrap items-center gap-2">
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            className={clsx(
+              'rounded-full px-4 py-1 text-xs font-semibold transition',
+              active === tab.key
+                ? 'bg-primary-500 text-white shadow'
+                : 'border border-slate-700 text-slate-300 hover:border-primary-400 hover:text-primary-200',
+            )}
+            onClick={() => setActive(tab.key)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </header>
+
+      <form className="mt-4 grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]" onSubmit={handleSubmit}>
+        <div className="space-y-2">
+          <label className="text-xs uppercase tracking-wide text-slate-400">{currentTab.helper}</label>
+          <input
+            type="text"
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            placeholder={currentTab.placeholder}
+            className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-primary-500 focus:outline-none"
+          />
+        </div>
+        <div className="flex items-end">
+          <button
+            type="submit"
+            className="h-10 rounded-lg bg-primary-500 px-4 text-sm font-semibold text-white shadow transition hover:bg-primary-400"
+          >
+            Buscar
+          </button>
+        </div>
+      </form>
+
+      <p className="mt-3 text-xs text-slate-400">
+        Integración pendiente: al buscar se mostrará información detallada en futuras versiones.
+      </p>
+    </section>
+  );
+};

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+import { clsx } from 'clsx';
+import { useToastStore } from '@/stores/useToastStore';
+
+const toneStyles: Record<string, string> = {
+  info: 'border-sky-400/70 bg-slate-900/90 text-slate-100',
+  success: 'border-emerald-400/70 bg-emerald-900/20 text-emerald-100',
+  warning: 'border-amber-400/70 bg-amber-900/20 text-amber-100',
+  error: 'border-red-400/70 bg-red-900/20 text-red-100',
+};
+
+export const ToastContainer = () => {
+  const { toasts, dismissToast } = useToastStore((state) => ({
+    toasts: state.toasts,
+    dismissToast: state.dismissToast,
+  }));
+
+  useEffect(() => {
+    if (!toasts.length) return;
+    const timers = toasts.map((toast) =>
+      window.setTimeout(() => {
+        dismissToast(toast.id);
+      }, toast.ttl ?? 5000),
+    );
+    return () => {
+      timers.forEach((timer) => window.clearTimeout(timer));
+    };
+  }, [toasts, dismissToast]);
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-[9999] flex flex-col items-center gap-3 p-4">
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          role="status"
+          className={clsx(
+            'pointer-events-auto flex w-full max-w-md items-start gap-3 rounded-xl border px-4 py-3 shadow-lg backdrop-blur',
+            toneStyles[toast.tone] ?? toneStyles.info,
+          )}
+        >
+          <div className="flex-1">
+            <p className="text-sm font-semibold">{toast.title}</p>
+            {toast.description ? <p className="mt-1 text-xs opacity-80">{toast.description}</p> : null}
+          </div>
+          <button
+            type="button"
+            className="mt-1 rounded-full p-1 text-xs text-current transition hover:bg-white/10"
+            onClick={() => dismissToast(toast.id)}
+          >
+            Cerrar
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -2,6 +2,7 @@
 import { useMemo } from 'react';
 import { clsx } from 'clsx';
 import { SearchBar } from './SearchBar';
+import { BarcodeScannerButton } from './barcode/BarcodeScannerButton';
 import type { ThemeMode } from '@/stores/useUiStore';
 
 interface TopBarProps {
@@ -9,6 +10,7 @@ interface TopBarProps {
   onQueryChange: (value: string) => void;
   onClearQuery: () => void;
   searchRef: RefObject<HTMLInputElement>;
+  onBarcodeScan: (code: string) => void;
   theme: ThemeMode;
   onToggleTheme: () => void;
   stores: string[];
@@ -27,6 +29,7 @@ export const TopBar = ({
   onQueryChange,
   onClearQuery,
   searchRef,
+  onBarcodeScan,
   theme,
   onToggleTheme,
   stores,
@@ -52,8 +55,9 @@ export const TopBar = ({
   return (
     <header className="flex flex-col gap-4 rounded-2xl border border-slate-800/80 bg-slate-950/70 p-4 shadow-lg lg:flex-row lg:items-center lg:justify-between">
       <div className="flex flex-1 items-center gap-3">
-        <div className="w-full max-w-xl">
+        <div className="flex w-full max-w-xl items-center gap-2">
           <SearchBar ref={searchRef} value={query} onChange={onQueryChange} onClear={onClearQuery} />
+          <BarcodeScannerButton onDetect={onBarcodeScan} />
         </div>
         <select
           className="h-10 rounded-lg border border-slate-700 bg-slate-900 px-3 text-sm text-slate-100 focus:border-primary-500 focus:outline-none"

--- a/frontend/src/components/barcode/BarcodeScannerButton.tsx
+++ b/frontend/src/components/barcode/BarcodeScannerButton.tsx
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { clsx } from 'clsx';
+
+interface Props {
+  onDetect: (code: string) => void;
+}
+
+type DetectorState = 'idle' | 'starting' | 'scanning' | 'unsupported';
+
+const stopStream = (stream: MediaStream | null) => {
+  stream?.getTracks().forEach((track) => track.stop());
+};
+
+export const BarcodeScannerButton = ({ onDetect }: Props) => {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const detectorRef = useRef<BarcodeDetector | null>(null);
+  const [state, setState] = useState<DetectorState>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const supported = useMemo(() => typeof window !== 'undefined' && 'BarcodeDetector' in window, []);
+
+  const stop = useCallback(() => {
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    stopStream(streamRef.current);
+    streamRef.current = null;
+    if (videoRef.current) {
+      videoRef.current.srcObject = null;
+    }
+    setState(supported ? 'idle' : 'unsupported');
+  }, [supported]);
+
+  const detectLoop = useCallback(async () => {
+    if (!detectorRef.current || !videoRef.current) return;
+    try {
+      const results = await detectorRef.current.detect(videoRef.current);
+      if (Array.isArray(results) && results.length > 0) {
+        const code = results[0]?.rawValue ?? '';
+        if (code) {
+          onDetect(code);
+          stop();
+          return;
+        }
+      }
+    } catch (err) {
+      console.warn('Barcode detection failed', err);
+    }
+    rafRef.current = requestAnimationFrame(detectLoop);
+  }, [onDetect, stop]);
+
+  const start = useCallback(async () => {
+    if (!supported) {
+      setState('unsupported');
+      return;
+    }
+    try {
+      setError(null);
+      setState('starting');
+      if (!detectorRef.current) {
+        detectorRef.current = new BarcodeDetector();
+      }
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: 'environment' },
+        audio: false,
+      });
+      streamRef.current = stream;
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        await videoRef.current.play();
+      }
+      setState('scanning');
+      rafRef.current = requestAnimationFrame(detectLoop);
+    } catch (err) {
+      console.warn('Unable to start barcode scanner', err);
+      setError('No se pudo acceder a la cámara');
+      stop();
+    }
+  }, [detectLoop, stop, supported]);
+
+  useEffect(() => {
+    if (!supported) {
+      setState('unsupported');
+      return () => undefined;
+    }
+    return () => stop();
+  }, [stop, supported]);
+
+  if (!supported) {
+    return null;
+  }
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        className={clsx(
+          'flex h-10 items-center gap-1 rounded-lg border border-slate-700 px-3 text-xs text-slate-200 transition hover:border-primary-400 hover:text-primary-200',
+          state === 'scanning' && 'border-primary-400 text-primary-200',
+        )}
+        onClick={() => {
+          if (state === 'scanning') {
+            stop();
+          } else {
+            void start();
+          }
+        }}
+        aria-pressed={state === 'scanning'}
+      >
+        <svg viewBox="0 0 24 24" className="h-4 w-4" aria-hidden="true">
+          <path
+            d="M4 7V5a1 1 0 011-1h2M4 17v2a1 1 0 001 1h2m12-4v2a1 1 0 01-1 1h-2m3-12V5a1 1 0 00-1-1h-2"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill="none"
+          />
+          <path d="M6 9h1v6H6zm3 0h1v6H9zm3 0h2v6h-2zm4 0h1v6h-1zm2 0h1v6h-1z" fill="currentColor" />
+        </svg>
+        <span>{state === 'scanning' ? 'Escaneando…' : 'Escanear'}</span>
+      </button>
+
+      {state === 'scanning' ? (
+        <div className="absolute right-0 top-12 z-40 w-64 rounded-xl border border-slate-800 bg-slate-950 p-3 shadow-lg">
+          <div className="flex items-center justify-between text-xs text-slate-300">
+            <span>Escaneando código…</span>
+            <button type="button" className="text-primary-300 hover:underline" onClick={stop}>
+              Detener
+            </button>
+          </div>
+          <div className="mt-2 overflow-hidden rounded-lg border border-slate-800">
+            <video ref={videoRef} className="h-36 w-full bg-black object-cover" muted playsInline />
+          </div>
+          {error ? <p className="mt-2 text-xs text-red-300">{error}</p> : null}
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/frontend/src/stores/useToastStore.ts
+++ b/frontend/src/stores/useToastStore.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand';
+
+export type ToastTone = 'info' | 'success' | 'warning' | 'error';
+
+export interface ToastItem {
+  id: string;
+  title: string;
+  description?: string;
+  tone: ToastTone;
+  createdAt: number;
+  ttl?: number;
+}
+
+interface ToastStoreState {
+  toasts: ToastItem[];
+  pushToast: (toast: Omit<ToastItem, 'id' | 'createdAt'> & { id?: string }) => void;
+  dismissToast: (id: string) => void;
+  clearToasts: () => void;
+}
+
+const DEFAULT_TTL = 5000;
+
+export const useToastStore = create<ToastStoreState>((set) => ({
+  toasts: [],
+  pushToast: ({ id, ttl, ...rest }) =>
+    set((state) => {
+      const toastId = id ?? crypto.randomUUID();
+      const next: ToastItem = {
+        id: toastId,
+        title: rest.title,
+        description: rest.description,
+        tone: rest.tone,
+        createdAt: Date.now(),
+        ttl: ttl ?? DEFAULT_TTL,
+      };
+      return { toasts: [...state.toasts.filter((toast) => toast.id !== toastId), next].slice(-5) };
+    }),
+  dismissToast: (id) => set((state) => ({ toasts: state.toasts.filter((toast) => toast.id !== id) })),
+  clearToasts: () => set({ toasts: [] }),
+}));

--- a/frontend/src/types/barcode.d.ts
+++ b/frontend/src/types/barcode.d.ts
@@ -1,0 +1,25 @@
+interface BarcodeDetectorOptions {
+  formats?: string[];
+}
+
+interface DetectedBarcode {
+  rawValue: string;
+  format: string;
+}
+
+declare class BarcodeDetector {
+  constructor(options?: BarcodeDetectorOptions);
+  detect(source: CanvasImageSource): Promise<DetectedBarcode[]>;
+}
+
+declare interface Navigator {
+  mediaDevices: MediaDevices;
+}
+
+declare global {
+  interface Window {
+    BarcodeDetector?: typeof BarcodeDetector;
+  }
+}
+
+export {};

--- a/frontend/src/utils/__tests__/totals.test.ts
+++ b/frontend/src/utils/__tests__/totals.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { calculateLineTotals, calculateCartTotals } from '@/utils/totals';
+import type { CartSnapshot, CartLine } from '@/types/cart';
+
+const baseLine = (overrides: Partial<CartLine> = {}): CartLine => ({
+  lineId: '1',
+  productId: 'sku',
+  code: 'SKU-001',
+  name: 'Producto de prueba',
+  price: 100,
+  iva: 21,
+  quantity: 1,
+  unit: 'un',
+  multiple: 1,
+  weightKg: 0.5,
+  discount: null,
+  ...overrides,
+});
+
+describe('calculateLineTotals', () => {
+  it('applies percent discount and IVA', () => {
+    const totals = calculateLineTotals(baseLine({ quantity: 2, discount: { type: 'percent', value: 10 } }));
+    expect(totals.gross).toBe(200);
+    expect(totals.discount).toBe(20);
+    expect(totals.net).toBe(180);
+    expect(totals.tax).toBeCloseTo(37.8, 2);
+    expect(totals.total).toBeCloseTo(217.8, 2);
+  });
+
+  it('caps amount discount to gross value', () => {
+    const totals = calculateLineTotals(baseLine({ price: 50, quantity: 1, discount: { type: 'amount', value: 80 } }));
+    expect(totals.gross).toBe(50);
+    expect(totals.discount).toBe(50);
+    expect(totals.net).toBe(0);
+    expect(totals.tax).toBe(0);
+    expect(totals.total).toBe(0);
+  });
+});
+
+describe('calculateCartTotals', () => {
+  const cart: CartSnapshot = {
+    lines: [
+      baseLine({ lineId: 'a', quantity: 3, price: 120, discount: { type: 'percent', value: 5 } }),
+      baseLine({ lineId: 'b', productId: 'sku-2', code: 'SKU-2', price: 80, quantity: 2, discount: null, iva: 10 }),
+    ],
+    client: null,
+    logistics: { mode: 'pickup', cost: 250 },
+    globalDiscountPercent: 10,
+    globalDiscountAmount: 50,
+    note: '',
+    payments: [],
+    simulatorTotals: undefined,
+    updatedAt: new Date().toISOString(),
+  };
+
+  it('summarizes totals with discounts and logistics', () => {
+    const totals = calculateCartTotals(cart);
+    expect(totals.subtotal).toBe(520);
+    expect(totals.lineDiscounts).toBeCloseTo(18, 2);
+    expect(totals.globalDiscounts).toBeCloseTo(83, 2);
+    expect(totals.tax).toBeGreaterThan(0);
+    expect(totals.logisticsCost).toBe(250);
+    expect(totals.total).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/utils/print.ts
+++ b/frontend/src/utils/print.ts
@@ -1,0 +1,103 @@
+import type { CartSnapshot, CartTotals } from '@/types/cart';
+
+const formatCurrency = (value: number) =>
+  value.toLocaleString('es-AR', { style: 'currency', currency: 'ARS', minimumFractionDigits: 2 });
+
+export const openQuotePrint = (cart: CartSnapshot, totals: CartTotals): boolean => {
+  if (typeof window === 'undefined') return false;
+  const win = window.open('', 'pos-quote', 'width=900,height=700');
+  if (!win) return false;
+
+  const linesHtml = cart.lines
+    .map(
+      (line) => `
+        <tr>
+          <td>${line.code}</td>
+          <td>${line.name}</td>
+          <td class="right">${line.quantity}</td>
+          <td class="right">${formatCurrency(line.price)}</td>
+          <td class="right">${line.discount ? (line.discount.type === 'percent' ? `${line.discount.value}%` : formatCurrency(line.discount.value)) : '—'}</td>
+          <td class="right">${formatCurrency(line.price * line.quantity)}</td>
+        </tr>
+      `,
+    )
+    .join('');
+
+  const html = `<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Presupuesto POS</title>
+    <style>
+      body { font-family: 'Segoe UI', Roboto, sans-serif; margin: 2rem; color: #0f172a; }
+      h1 { margin-bottom: 0.5rem; }
+      table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+      th, td { border: 1px solid #cbd5f5; padding: 0.5rem; font-size: 0.9rem; }
+      th { background: #e0e7ff; text-align: left; }
+      .right { text-align: right; }
+      .totals { margin-top: 1.5rem; width: 100%; max-width: 20rem; float: right; }
+      .totals tr td { border: none; }
+      .totals tr:nth-child(odd) { background: rgba(79, 70, 229, 0.05); }
+      .meta { font-size: 0.85rem; color: #64748b; margin-top: 0.5rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Presupuesto</h1>
+    <p class="meta">Fecha: ${new Date().toLocaleString('es-AR')}</p>
+    ${cart.client ? `<p class="meta">Cliente: ${cart.client.name}${cart.client.document ? ` · ${cart.client.document}` : ''}</p>` : ''}
+    <table>
+      <thead>
+        <tr>
+          <th>Código</th>
+          <th>Producto</th>
+          <th class="right">Cant.</th>
+          <th class="right">Precio</th>
+          <th class="right">Descuento</th>
+          <th class="right">Importe</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${linesHtml || '<tr><td colspan="6">Sin ítems</td></tr>'}
+      </tbody>
+    </table>
+    <table class="totals">
+      <tbody>
+        <tr>
+          <td>Subtotal</td>
+          <td class="right">${formatCurrency(totals.subtotal)}</td>
+        </tr>
+        <tr>
+          <td>Descuentos líneas</td>
+          <td class="right">-${formatCurrency(totals.lineDiscounts)}</td>
+        </tr>
+        <tr>
+          <td>Descuento global</td>
+          <td class="right">-${formatCurrency(totals.globalDiscounts)}</td>
+        </tr>
+        <tr>
+          <td>IVA</td>
+          <td class="right">${formatCurrency(totals.tax)}</td>
+        </tr>
+        <tr>
+          <td>Logística</td>
+          <td class="right">${formatCurrency(totals.logisticsCost)}</td>
+        </tr>
+        <tr>
+          <td><strong>Total</strong></td>
+          <td class="right"><strong>${formatCurrency(totals.total)}</strong></td>
+        </tr>
+      </tbody>
+    </table>
+    ${cart.note ? `<p class="meta">Notas: ${cart.note}</p>` : ''}
+    <script>
+      setTimeout(() => { window.print(); }, 200);
+    </script>
+  </body>
+</html>`;
+
+  win.document.open();
+  win.document.write(html);
+  win.document.close();
+  win.focus();
+  return true;
+};

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,14 @@
-﻿import { defineConfig } from 'vite';
+import { defineConfig } from 'vite';
+import { fileURLToPath, URL } from 'node:url';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   server: {
     host: '0.0.0.0',
     port: 5173,
@@ -20,5 +26,9 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
+  },
+  test: {
+    globals: true,
+    environment: 'node',
   },
 });


### PR DESCRIPTION
## Summary
- add a toast store/container and surface sync and client feedback throughout the POS
- introduce a camera-enabled barcode scanner control plus auxiliary order/quote search placeholders
- enable printable quotes, update documentation, and wire vitest totals coverage with Vite path aliases

## Testing
- npm install *(fails: 403 Forbidden while downloading vitest from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_68d948212e3c83239aadd7e5964068e3