### PR TITLE
Add frontend dev service to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,12 +71,33 @@ services:
       timeout: 5s
       retries: 5
 
+  frontend:
+    image: node:20-alpine
+    container_name: mypos_frontend
+    working_dir: /app
+    environment:
+      VITE_BACKEND_URL: "http://web:8000"
+      VITE_PORT: "3000"
+      NODE_ENV: development
+    volumes:
+      - ./frontend:/app
+      - frontend_node_modules:/app/node_modules
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0 --port 3000"
+    ports:
+      - "3000:3000"
+    depends_on:
+      - web
+    restart: unless-stopped
+    networks:
+      - default
+
 volumes:
   staticfiles:
   logs:
   servicesdb:
   cache:
   sessions:
+  frontend_node_modules:
 
 networks:
   default:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,34 +1,41 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import { fileURLToPath, URL } from 'node:url';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-    },
-  },
-  server: {
-    host: '0.0.0.0',
-    port: 5173,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-      },
-      '/producto': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-      },
-      '/auth_app': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+
+  const backendUrl = env.VITE_BACKEND_URL || 'http://localhost:8000';
+  const devServerPort = Number(env.VITE_PORT ?? '') || 5173;
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
       },
     },
-  },
-  test: {
-    globals: true,
-    environment: 'node',
-  },
+    server: {
+      host: '0.0.0.0',
+      port: devServerPort,
+      proxy: {
+        '/api': {
+          target: backendUrl,
+          changeOrigin: true,
+        },
+        '/producto': {
+          target: backendUrl,
+          changeOrigin: true,
+        },
+        '/auth_app': {
+          target: backendUrl,
+          changeOrigin: true,
+        },
+      },
+    },
+    test: {
+      globals: true,
+      environment: 'node',
+    },
+  };
 });


### PR DESCRIPTION
## Summary
- add a Node-based frontend service so the React app starts alongside the backend when docker-compose boots
- make the Vite dev server proxy configurable via environment variables for container usage

## Testing
- npm run build *(fails: existing TypeScript errors in the project)*

------
https://chatgpt.com/codex/tasks/task_b_68d9546032b88323b39085e4739ad0e8