### PR TITLE
Bootstrap POS stores from Django scripts

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -36,6 +36,20 @@ Durante el desarrollo Vite proxea automáticamente `/api`, `/producto` y `/auth_
 <link rel="stylesheet" href="{% static 'pos/assets/index-XYZ.css' %}" />
 ```
 
+### Scripts de bootstrap compatibles con Django
+
+Para mantener la compatibilidad con el template actual de Django, la plantilla debe inyectar dos scripts JSON antes de montar la SPA:
+
+```html
+<script id="backend-stores-data" type="application/json">{{ stores_json|safe }}</script>
+<script id="backend-last-store-data" type="application/json">{{ last_store_json|safe }}</script>
+```
+
+- `backend-stores-data` debe contener la lista de sucursales disponibles (array de strings o un objeto con la clave `stores`).
+- `backend-last-store-data` expone la última sucursal seleccionada (string u objeto con la clave `last_store`).
+
+La app lee estos scripts al iniciar para hidratar `useSessionStore.setStores` y `useFiltersStore.setStoreId` si la respuesta de `/api/user_info` no provee sucursales, evitando romper la experiencia existente mientras conviven ambas fuentes de datos.
+
 ## Hotkeys por defecto
 
 | Acción | Atajo |

--- a/frontend/src/pages/POS.tsx
+++ b/frontend/src/pages/POS.tsx
@@ -20,6 +20,7 @@ import { StockByStoreModal } from '@/components/StockByStoreModal';
 import { ClientSearch } from '@/components/ClientSearch';
 import { Modal } from '@/components/Modal';
 import { AuxiliarySearchPanels } from '@/components/AuxiliarySearchPanels';
+import { getBootstrapData } from '@/utils/bootstrap';
 import type { Product } from '@/types/product';
 
 const normalize = (value: string) =>
@@ -113,6 +114,22 @@ export const POSPage = () => {
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
   const [stockProduct, setStockProduct] = useState<Product | null>(null);
 
+  const bootstrapData = useMemo(() => getBootstrapData(), []);
+
+  useEffect(() => {
+    if (!stores.length && bootstrapData.stores?.length) {
+      setStores(bootstrapData.stores);
+    }
+  }, [bootstrapData, setStores, stores.length]);
+
+  useEffect(() => {
+    if (storeId) return;
+    const fallbackStore = bootstrapData.lastStoreId ?? bootstrapData.stores?.[0] ?? null;
+    if (fallbackStore) {
+      setStoreId(fallbackStore);
+    }
+  }, [bootstrapData, setStoreId, storeId]);
+
   const userInfoQuery = useQuery({
     queryKey: queryKeys.userInfo,
     queryFn: fetchUserInfo,
@@ -137,8 +154,28 @@ export const POSPage = () => {
       if (!storeId) {
         setStoreId(info.last_store ?? availableStores[0]);
       }
+      return;
     }
-  }, [userInfoQuery.data, setUser, setStores, storeId, setStoreId]);
+
+    if (!stores.length && bootstrapData.stores?.length) {
+      setStores(bootstrapData.stores);
+    }
+    if (!storeId) {
+      const fallbackStore =
+        info.last_store ?? bootstrapData.lastStoreId ?? bootstrapData.stores?.[0] ?? null;
+      if (fallbackStore) {
+        setStoreId(fallbackStore);
+      }
+    }
+  }, [
+    bootstrapData,
+    setUser,
+    setStores,
+    storeId,
+    setStoreId,
+    stores.length,
+    userInfoQuery.data,
+  ]);
 
   useQuery({
     queryKey: queryKeys.remoteCart,

--- a/frontend/src/utils/bootstrap.ts
+++ b/frontend/src/utils/bootstrap.ts
@@ -1,0 +1,71 @@
+const STORES_SCRIPT_ID = 'backend-stores-data';
+const LAST_STORE_SCRIPT_ID = 'backend-last-store-data';
+
+export type BootstrapData = {
+  stores: string[] | null;
+  lastStoreId: string | null;
+};
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string');
+
+const readScriptContent = (id: string): string | null => {
+  if (typeof document === 'undefined') return null;
+  const element = document.getElementById(id);
+  if (!element) return null;
+  const content = element.textContent?.trim();
+  return content && content.length > 0 ? content : null;
+};
+
+const parseJson = (content: string | null): unknown => {
+  if (!content) return null;
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    console.warn(`No se pudo parsear el script bootstrap: ${content.slice(0, 40)}...`, error);
+    return null;
+  }
+};
+
+const extractStores = (value: unknown): string[] | null => {
+  if (isStringArray(value)) return value;
+  if (typeof value === 'object' && value !== null) {
+    const candidate =
+      (value as Record<string, unknown>).stores ??
+      (value as Record<string, unknown>).available_stores ??
+      (value as Record<string, unknown>).stores_available;
+    if (isStringArray(candidate)) return candidate;
+  }
+  return null;
+};
+
+const extractLastStoreId = (value: unknown): string | null => {
+  if (typeof value === 'string' && value) return value;
+  if (typeof value === 'object' && value !== null) {
+    const candidate =
+      (value as Record<string, unknown>).last_store ??
+      (value as Record<string, unknown>).lastStore ??
+      (value as Record<string, unknown>).id;
+    if (typeof candidate === 'string' && candidate) return candidate;
+  }
+  return null;
+};
+
+let cachedData: BootstrapData | null = null;
+
+export const getBootstrapData = (): BootstrapData => {
+  if (cachedData) return cachedData;
+
+  const storesPayload = parseJson(readScriptContent(STORES_SCRIPT_ID));
+  const lastStorePayload = parseJson(readScriptContent(LAST_STORE_SCRIPT_ID));
+
+  const stores = extractStores(storesPayload);
+  const lastStoreId = extractLastStoreId(lastStorePayload);
+
+  cachedData = {
+    stores,
+    lastStoreId,
+  };
+
+  return cachedData;
+};


### PR DESCRIPTION
## Summary
- read Django-provided bootstrap scripts before issuing data queries in the POS page
- add a typed bootstrap utility that parses script payloads and exposes the data safely
- document how Django must inject the bootstrap scripts when mounting the SPA

## Testing
- pnpm test --filter bootstrap --no-bail *(fails: vitest not found / dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68d968c23dc08323b40af6fd7e934df7