### PR TITLE
Add missing base layout template

### DIFF
--- a/app/src/core/templates/layout.html
+++ b/app/src/core/templates/layout.html
@@ -1,0 +1,29 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="es" class="h-100">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}MyPOS{% endblock %}</title>
+    <link rel="icon" type="image/png" href="{% static 'img/favicon.png' %}" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous"
+    />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
+    <link rel="stylesheet" href="{% static 'css/styles.css' %}" />
+    {% block extra_head %}{% endblock %}
+  </head>
+  <body class="d-flex flex-column min-vh-100">
+    <main class="flex-grow-1">
+      {% block content %}{% endblock %}
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <script src="{% static 'vendor/bootstrap/bootstrap.bundle.min.js' %}"></script>
+    {% block extra_scripts %}{% endblock %}
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a reusable `layout.html` template under `core/templates`
- provide Bootstrap resources, favicon, and template blocks used by login and config pages

## Testing
- not run (Python dependencies could not be installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68d96e337e2c8323ae3e0c7b5f691cac