### PR TITLE
Ensure frontend login uses same host and update cache path

### DIFF
--- a/app/src/core/scheduler.py
+++ b/app/src/core/scheduler.py
@@ -237,7 +237,7 @@ def start_scheduler_and_jobs():
     # Cachés “simples”
     # NOTE: TODOS los archivos parquet (productos, clientes, stock, atributos, 
     # empleados, codigos_postales) ahora los publica un proceso externo
-    # en /srv/data/parquet (Linux) o C:\cache (Windows).
+    # en /srv/data/cache (Linux) o C:\cache (Windows).
     # Este scheduler solo mantiene jobs para datos que NO son parquet.
 
     # Semanales (datos que van a la base de datos, no a parquet)

--- a/app/src/services/caching.py
+++ b/app/src/services/caching.py
@@ -54,7 +54,7 @@ except Exception:
 # ----------------------------------------------------------------------
 # Si ya las cargas de otro lado, puedes borrar estas constantes.
 # The external system now places parquet files in SERVICES_CACHE_DIR (default
-# /srv/data/parquet). The old behavior downloaded these files from Fabric; we
+# /srv/data/cache). The old behavior downloaded these files from Fabric; we
 # keep the constants for reference but scheduler-based downloads are removed.
 PRODUCTOS_PARQUET_URL = None
 CLIENTES_PARQUET_URL = None

--- a/app/src/services/config.py
+++ b/app/src/services/config.py
@@ -3,7 +3,7 @@ import platform
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 # By default parquet files are now stored in the server directory requested
-# External process will post .parquet files to /srv/data/parquet (Linux: QA/PROD) 
+# External process will post .parquet files to /srv/data/cache (Linux: QA/PROD)
 # or C:\cache (Windows: DEV). Allow override via SERVICES_CACHE_DIR env var.
 
 # Detectar el sistema operativo para usar el directorio correcto
@@ -12,7 +12,7 @@ if os.environ.get("SERVICES_CACHE_DIR"):
 elif platform.system() == "Windows":
     DEFAULT_CACHE_DIR = "C:\\cache"
 else:
-    DEFAULT_CACHE_DIR = "/srv/data/parquet"
+    DEFAULT_CACHE_DIR = "/srv/data/cache"
 # Ensure directory exists (no-op if the path already exists or if permissions
 # prevent creation; failures will raise as usual).
 CACHE_DIR = DEFAULT_CACHE_DIR

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -17,7 +17,7 @@ pnpm preview      # sirve el build para verificación
 pnpm test         # ejecuta las pruebas unitarias (Vitest)
 ```
 
-Durante el desarrollo Vite proxea automáticamente `/api`, `/producto` y `/auth_app` hacia `http://localhost:8000` para evitar problemas de CORS.
+Durante el desarrollo Vite proxea automáticamente `/api`, `/producto`, `/auth_app` y `/auth` hacia `http://localhost:8000` para evitar problemas de CORS y mantener los redireccionamientos de login en el mismo host del frontend.
 
 ## Integración con Django
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,11 @@ export default defineConfig(({ mode }) => {
   const backendUrl = env.VITE_BACKEND_URL || 'http://localhost:8000';
   const devServerPort = Number(env.VITE_PORT ?? '') || 5173;
 
+  const createProxyConfig = () => ({
+    target: backendUrl,
+    changeOrigin: false,
+  });
+
   return {
     plugins: [react()],
     resolve: {
@@ -19,18 +24,10 @@ export default defineConfig(({ mode }) => {
       host: '0.0.0.0',
       port: devServerPort,
       proxy: {
-        '/api': {
-          target: backendUrl,
-          changeOrigin: true,
-        },
-        '/producto': {
-          target: backendUrl,
-          changeOrigin: true,
-        },
-        '/auth_app': {
-          target: backendUrl,
-          changeOrigin: true,
-        },
+        '/api': createProxyConfig(),
+        '/producto': createProxyConfig(),
+        '/auth_app': createProxyConfig(),
+        '/auth': createProxyConfig(),
       },
     },
     test: {


### PR DESCRIPTION
## Summary
- update the Vite dev proxy so /auth requests stay on the frontend host and add documentation for it
- default the services cache directory to /srv/data/cache and refresh related comments

## Testing
- npm test -- --run *(fails: known failure in totals.test.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68d9826a2ea883239a810367ed4da336