### PR TITLE
Add Django REST framework dependency

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,6 +3,7 @@ APScheduler
 asgiref
 certifi
 charset-normalizer
+djangorestframework
 Django
 h11
 httpcore


### PR DESCRIPTION
## Summary
- add the Django REST framework package to the backend requirements to resolve the missing module error during startup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d9897cdea88323b2050892e97821f3