### PR TITLE
Default frontend dev server to port 3000

### DIFF
--- a/app/src/buscador_django/settings.py
+++ b/app/src/buscador_django/settings.py
@@ -15,8 +15,9 @@ def _split_env_list(value: str):
 
 ALLOWED_HOSTS = [h.strip() for h in os.getenv("DJANGO_ALLOWED_HOSTS","").split(",") if h.strip()]
 CSRF_TRUSTED_ORIGINS = [o.strip() for o in os.getenv("DJANGO_CSRF_TRUSTED_ORIGINS","").split(",") if o.strip()]
-if 'http://localhost:5173' not in CSRF_TRUSTED_ORIGINS:
-    CSRF_TRUSTED_ORIGINS.append('http://localhost:5173')
+for default_origin in ('http://localhost:3000', 'http://localhost:5173'):
+    if default_origin not in CSRF_TRUSTED_ORIGINS:
+        CSRF_TRUSTED_ORIGINS.append(default_origin)
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -11,7 +11,7 @@ Single screen Point of Sale UI built with React 18, TypeScript, Tailwind CSS, Zu
 
 ```bash
 pnpm install      # instala dependencias
-pnpm dev          # arranca Vite en modo desarrollo (http://localhost:5173)
+pnpm dev          # arranca Vite en modo desarrollo (http://localhost:3000)
 pnpm build        # genera build listo para producción en dist/
 pnpm preview      # sirve el build para verificación
 pnpm test         # ejecuta las pruebas unitarias (Vitest)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
 
   const backendUrl = env.VITE_BACKEND_URL || 'http://localhost:8000';
-  const devServerPort = Number(env.VITE_PORT ?? '') || 5173;
+  const devServerPort = Number(env.VITE_PORT) || 3000;
 
   const createProxyConfig = () => ({
     target: backendUrl,


### PR DESCRIPTION
## Summary
- set the Vite development server to default to port 3000 so it matches the expected frontend URL
- include localhost:3000 in the Django CSRF trusted origins list while preserving the previous entry
- update the frontend README to mention the new default port

## Testing
- npm run build *(fails: pre-existing TypeScript errors in ClientSearch, POS, totals utilities, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68d9970594988323be710478ac8c9807