### PR TITLE
Gracefully handle backend downtime in frontend

### DIFF
--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -75,15 +75,28 @@ export const request = async <T = unknown>(input: string, options: RequestOption
     };
   }
 
-  const response = await fetch(input, { ...init, method });
-  const payload = await parseResponse(response, parseAs);
+  try {
+    const response = await fetch(input, { ...init, method });
+    const payload = await parseResponse(response, parseAs);
 
-  if (!response.ok) {
-    const message = typeof payload === 'string' && payload ? payload : response.statusText || 'Request failed';
-    throw new ApiError(message, response.status, payload);
+    if (!response.ok) {
+      const message = typeof payload === 'string' && payload ? payload : response.statusText || 'Request failed';
+      throw new ApiError(message, response.status, payload);
+    }
+
+    return payload as T;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : 'No se pudo conectar con el backend. Verificá que el servicio esté disponible.';
+
+    throw new ApiError(message, 0, null);
   }
-
-  return payload as T;
 };
 
 export const get = <T = unknown>(url: string, options?: RequestOptions) =>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,12 +5,19 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import App from './App';
 import './index.css';
+import { ApiError } from '@/api/http';
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
-      retry: 1,
+      retry: (failureCount, error) => {
+        if (error instanceof ApiError && error.status === 0) {
+          return false;
+        }
+
+        return failureCount < 1;
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- wrap the shared HTTP helper to translate network failures into a consistent ApiError with a clearer message
- stop retrying React Query requests when the backend is offline to avoid endless proxy errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d99f7059ac83238f1855a909e06d56