### PR TITLE
Add default headers for API requests

### DIFF
--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -37,9 +37,15 @@ const isBodyInit = (value: unknown): value is BodyInit => {
 
 export const request = async <T = unknown>(input: string, options: RequestOptions = {}): Promise<T> => {
   const { parseAs = 'json', headers, method, body, ...rest } = options;
+  const defaultHeaders: HeadersInit = {
+    'X-Requested-With': 'XMLHttpRequest',
+    Accept: 'application/json',
+  };
+
   const init: RequestInit = {
     ...rest,
     headers: {
+      ...defaultHeaders,
       ...(headers ?? {}),
     },
     credentials: rest.credentials ?? 'include',


### PR DESCRIPTION
## Summary
- add default X-Requested-With and Accept headers to every API request so the backend recognizes them as AJAX calls

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_b_68d9b080af3083238f35c11a717ec8aa