### PR TITLE
Integrate product search API with POS filters

### DIFF
--- a/frontend/src/api/products.ts
+++ b/frontend/src/api/products.ts
@@ -1,12 +1,10 @@
-﻿import { get } from './http';
+import { get } from './http';
 import { normalizeProduct, normalizeStockRow } from '@/utils/normalizers';
 import type { Product, ProductResponse } from '@/types/product';
 import type { StockRow, StockRowResponse } from '@/types/stock';
+import type { SortOption, StockFilters } from '@/stores/useFiltersStore';
 
-const PAGE_SIZE = 5000;
-const MAX_PAGES = 200;
-
-const buildQuery = (params: Record<string, string | number | null | undefined>) => {
+const buildQuery = (params: Record<string, string | number | boolean | null | undefined>) => {
   const searchParams = new URLSearchParams();
   Object.entries(params).forEach(([key, value]) => {
     if (value === null || value === undefined || value === '') return;
@@ -16,18 +14,89 @@ const buildQuery = (params: Record<string, string | number | null | undefined>) 
   return query ? `?${query}` : '';
 };
 
-export const fetchAllProducts = async (storeId: string): Promise<Product[]> => {
-  const results: Product[] = [];
-  let page = 1;
-  while (page <= MAX_PAGES) {
-    const query = buildQuery({ store: storeId, page, items_per_page: PAGE_SIZE });
-    const data = await get<ProductResponse[]>(`/api/productos${query}`);
-    if (!Array.isArray(data) || data.length === 0) break;
-    results.push(...data.map(normalizeProduct));
-    if (data.length < PAGE_SIZE) break;
-    page += 1;
-  }
-  return results;
+const toStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => (typeof item === 'string' ? item.trim() : String(item ?? '').trim()))
+    .filter((item): item is string => item.length > 0);
+};
+
+export interface SearchProductsParams {
+  storeId?: string | null;
+  query?: string;
+  category?: string;
+  coverageGroup?: string;
+  minPrice?: number | null;
+  maxPrice?: number | null;
+  stock?: StockFilters;
+  sort?: SortOption;
+  page?: number;
+  perPage?: number;
+}
+
+interface SearchProductsApiResponse {
+  items?: ProductResponse[];
+  total?: number;
+  page?: number;
+  per_page?: number;
+  total_pages?: number;
+  facets?: {
+    categories?: string[];
+    coverage_groups?: string[];
+  };
+  categories?: string[];
+  coverage_groups?: string[];
+}
+
+export interface ProductsSearchResult {
+  items: Product[];
+  total: number;
+  page: number;
+  perPage: number;
+  totalPages: number;
+  categories: string[];
+  coverageGroups: string[];
+}
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PER_PAGE = 20;
+
+export const searchProducts = async (params: SearchProductsParams): Promise<ProductsSearchResult> => {
+  const query = buildQuery({
+    store: params.storeId ?? undefined,
+    query: params.query ?? undefined,
+    category: params.category ?? undefined,
+    coverage_group: params.coverageGroup ?? undefined,
+    min_price: params.minPrice ?? undefined,
+    max_price: params.maxPrice ?? undefined,
+    stock_positive: params.stock?.positive,
+    stock_zero: params.stock?.zero,
+    stock_negative: params.stock?.negative,
+    sort: params.sort ?? undefined,
+    page: params.page ?? undefined,
+    per_page: params.perPage ?? undefined,
+  });
+
+  const data = await get<SearchProductsApiResponse>(`/api/productos/search${query}`);
+
+  const items = Array.isArray(data?.items) ? data.items.map(normalizeProduct) : [];
+  const page = typeof data?.page === 'number' ? data.page : params.page ?? DEFAULT_PAGE;
+  const perPage = typeof data?.per_page === 'number' ? data.per_page : params.perPage ?? DEFAULT_PER_PAGE;
+  const total = typeof data?.total === 'number' ? data.total : items.length;
+  const totalPages = typeof data?.total_pages === 'number' ? data.total_pages : Math.max(1, Math.ceil(total / perPage));
+  const facets = data?.facets ?? {};
+  const categories = toStringArray(facets.categories ?? data?.categories);
+  const coverageGroups = toStringArray(facets.coverage_groups ?? data?.coverage_groups);
+
+  return {
+    items,
+    total,
+    page,
+    perPage,
+    totalPages,
+    categories,
+    coverageGroups,
+  };
 };
 
 export const fetchProductByCode = async (

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -1,5 +1,35 @@
-﻿export const queryKeys = {
-  products: (storeId: string) => ['products', storeId] as const,
+import type { SortOption, StockFilters } from '@/stores/useFiltersStore';
+
+export interface ProductsQueryKey {
+  storeId: string | null;
+  query: string;
+  category: string;
+  coverageGroup: string;
+  minPrice: number | null;
+  maxPrice: number | null;
+  stock: StockFilters;
+  sort: SortOption;
+  page: number;
+  perPage: number;
+}
+
+export const queryKeys = {
+  products: (params: ProductsQueryKey) =>
+    [
+      'products',
+      params.storeId ?? '',
+      params.query,
+      params.category,
+      params.coverageGroup,
+      params.minPrice ?? '',
+      params.maxPrice ?? '',
+      params.stock.positive,
+      params.stock.zero,
+      params.stock.negative,
+      params.sort,
+      params.page,
+      params.perPage,
+    ] as const,
   productByCode: (code: string, storeId?: string | null) => ['productByCode', code, storeId ?? ''] as const,
   stock: (code: string, storeId: string) => ['stock', code, storeId] as const,
   productAttributes: (productId: string) => ['productAttributes', productId] as const,

--- a/frontend/src/stores/useFiltersStore.ts
+++ b/frontend/src/stores/useFiltersStore.ts
@@ -10,7 +10,7 @@ export type SortOption =
   | 'nameDesc'
   | 'stockDesc';
 
-interface StockFilters {
+export interface StockFilters {
   positive: boolean;
   zero: boolean;
   negative: boolean;


### PR DESCRIPTION
## Summary
- add a server-side `/api/productos/search` endpoint that handles filters, sorting, and facets for catalog queries
- update the product API client and query keys to request paginated search results with filter metadata
- wire the POS page to use the new search response instead of client-side filtering and export stock filter types for reuse

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d9c205c4a083239f2a302b8da6a6df