### PR TITLE
Fix HTTP client fallback for dotless backend hosts

### DIFF
--- a/frontend/src/api/__tests__/http.test.ts
+++ b/frontend/src/api/__tests__/http.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalFetch = globalThis.fetch;
+
+describe('http client', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+    } else {
+      delete (globalThis as typeof globalThis & { fetch?: typeof fetch }).fetch;
+    }
+  });
+
+  it('uses the configured backend URL even if the hostname has no dots', async () => {
+    vi.stubEnv('VITE_BACKEND_URL', 'http://web:8000');
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: vi.fn().mockResolvedValue({ ok: true }),
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { get } = await import('../http');
+
+    await get('/api/test');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('http://web:8000/api/test');
+  });
+});

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -37,7 +37,7 @@ const isBodyInit = (value: unknown): value is BodyInit => {
 
 const isAbsoluteUrl = (url: string) => /^https?:\/\//i.test(url);
 
-const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0']);
 
 const removeTrailingSlash = (value: string) => (value.endsWith('/') ? value.slice(0, -1) : value);
 
@@ -57,8 +57,7 @@ const shouldFallbackToBrowserOrigin = (url: URL) => {
   if (LOCAL_HOSTS.has(normalizedHost)) return false;
   if (normalizedHost === window.location.hostname.toLowerCase()) return false;
 
-  const looksInternalNetworkHost = !normalizedHost.includes('.');
-  return looksInternalNetworkHost;
+  return false;
 };
 
 const getBaseUrl = () => {


### PR DESCRIPTION
## Summary
- stop the frontend HTTP client from falling back to the browser origin when VITE_BACKEND_URL points to a dotless hostname
- extend the local host allowlist and add a regression test covering internal hostnames without dots

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_b_68d9c7e160388323bf075c33546b36a7