### PR TITLE
Fix API container entrypoint lookup

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -25,9 +25,10 @@ RUN pip install --no-cache-dir -r /app/requirements.txt
 RUN useradd -m -u 1000 app
 
 COPY src /app
-COPY entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
-RUN chmod +x /entrypoint.sh \
+RUN sed -i 's/\r$//' /usr/local/bin/entrypoint.sh \
+    && chmod +x /usr/local/bin/entrypoint.sh \
     && mkdir -p /app/logs /data/services_db /data/cache \
     && chown -R app:app /app /data \
     && chmod -R 755 /app /data \
@@ -35,4 +36,4 @@ RUN chmod +x /entrypoint.sh \
 
 USER app
 EXPOSE 8000
-CMD ["/entrypoint.sh"]
+CMD ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- install the API entrypoint script into /usr/local/bin to avoid lookup issues
- normalize the script's line endings during the image build and update the CMD path

## Testing
- not run (docker not available in CI environment)

------
https://chatgpt.com/codex/tasks/task_b_68d9e0f2f2308323942884b35d005f28